### PR TITLE
fixed a bug cant initaiate stk push after adding sandbox

### DIFF
--- a/src/Mpesa/App.php
+++ b/src/Mpesa/App.php
@@ -20,7 +20,9 @@ class App
      * @return bool returns false if MPESA_SANDBOX is set to false in .env
      */
     public function isSandbox(): bool{
-        if(isset($_ENV['MPESA_SANDBOX'])) return boolval($_ENV['MPESA_SANDBOX']);
+        if(isset($_ENV['MPESA_SANDBOX'])){
+            if(trim($_ENV['MPESA_SANDBOX'])=='true') return true;
+        }
         return false;
     }
 
@@ -28,7 +30,7 @@ class App
     public function getLiveToken()
     {
         $headers = ['Content-Type:application/json; charset=utf8'];
-        $access_token_url = 'https://'.$this->isSandbox()?'sandbox':'api'.'.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials';
+        $access_token_url = 'https://'.($this->isSandbox()?'sandbox':'api').'.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials';
 
         $curl = curl_init($access_token_url);
         curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);

--- a/src/Mpesa/StkPush.php
+++ b/src/Mpesa/StkPush.php
@@ -20,7 +20,7 @@ class StkPush extends App
         parent::__construct($root);
         // initialize dot env
         Dotenv::createImmutable($this->app_root)->load();
-        $this->initiate_url='https://'.$this->isSandbox()?'sandbox':'api'.'.safaricom.co.ke/mpesa/stkpush/v1/processrequest';
+        $this->initiate_url='https://'.($this->isSandbox()?'sandbox':'api').'.safaricom.co.ke/mpesa/stkpush/v1/processrequest';
     }
 
     public function setCallbackUrl($url)

--- a/test.php
+++ b/test.php
@@ -1,8 +1,16 @@
 <?php
 
 require_once realpath(__DIR__ . '/vendor/autoload.php');
-
 use Techlup\PaymentGateway\Mpesa\StkPush;
-echo json_encode(StkPush::getCallbackData());
-echo "\n";
+
+$data = new StkPush('./');
+$data->setCallbackUrl("https://en9hu12xsn4f7.x.pipedream.net/") // required
+->setAmount("10") // required
+->setPhone("254724974848") // required 254*********
+->setReference("test") //reuired * e.g account number, room number, etc
+->setRemarks("testing api"); // optional
+
+$response = $data->tillRequestPush();
+
+print_r($response);
 ?>


### PR DESCRIPTION
## what this PR does.

I have fixed a bug where the stk push failed to initiate, the problem was that there was an error reading sandbox from the env file and also concatenating the strings 'sandbox' and 'api' using the ternary operator.

### getting sandbox

```php
// Before
public function isSandbox(): bool{
        if(isset($_ENV['MPESA_SANDBOX'])) return boolval($_ENV['MPESA_SANDBOX']);
        return false;
}

// After
public function isSandbox(): bool{
        if(isset($_ENV['MPESA_SANDBOX'])){
            if(trim($_ENV['MPESA_SANDBOX'])=='true') return true;
        }
        return false;
}
```


### concatenating the url

```php
// before
$access_token_url = 'https://'.$this->isSandbox()?'sandbox':'api'.'.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials';

// after
$access_token_url = 'https://'.($this->isSandbox()?'sandbox':'api').'.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials';
```

## feedback

feel free to leave a comment if you have any issues or suggestion